### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Install latest version from the repository
 $ pip3 install --upgrade git+https://github.com/essembeh/gnome-extensions-cli
 ```
 
+Install with [pipx](https://github.com/pypa/pipx)
+
+```sh
+$ pipx install gnome-extensions-cli --system-site-packages
+```
+
 Or setup a development environment
 
 ```sh


### PR DESCRIPTION
Installing `gnome-extensions-cli` with `pipx` installs it to its own virtualenv, and makes it easy to keep it up-to-date. By passing the `--system-site-packages` argument to `pipx`, it ensures that the virtualenv still has access to system packages, thus avoiding the issue would otherwise come from installing this way.