### PR TITLE
feat: print only uuid extensions in list command

### DIFF
--- a/gnome_extensions_cli/commands/list_.py
+++ b/gnome_extensions_cli/commands/list_.py
@@ -19,7 +19,7 @@ def configure(parser: ArgumentParser):
         "-v", "--verbose", action="store_true", help="display more information"
     )
     parser.add_argument(
-        "--only-uuid", action="store_true", help="display only uuid of extention"
+        "--only-uuid", action="store_true", help="display only uuid of extensions"
     )
     parser.add_argument(
         "-a",

--- a/gnome_extensions_cli/commands/list_.py
+++ b/gnome_extensions_cli/commands/list_.py
@@ -19,6 +19,9 @@ def configure(parser: ArgumentParser):
         "-v", "--verbose", action="store_true", help="display more information"
     )
     parser.add_argument(
+        "--only-uuid", action="store_true", help="display only uuid of extention"
+    )
+    parser.add_argument(
         "-a",
         "--all",
         action="store_true",
@@ -32,6 +35,7 @@ def run(args: Namespace, manager: ExtensionManager, _store: GnomeExtensionStore)
     """
     verbose = "verbose" in args and args.verbose
     show_all = "all" in args and args.all
+    only_uuid = "only_uuid" in args and args.only_uuid
 
     if verbose:
         print("Gnome Shell", Label.version(manager.get_current_shell_version()))
@@ -48,12 +52,20 @@ def run(args: Namespace, manager: ExtensionManager, _store: GnomeExtensionStore)
 
     for installed_ext in installed_extensions:
         if installed_ext.uuid in enabled_uuids:
-            print(Icons.DOT_BLUE, Label.installed(installed_ext, enabled=True))
+            if only_uuid:
+                print(installed_ext.metadata.uuid)
+            else:
+                print(Icons.DOT_BLUE, Label.installed(installed_ext, enabled=True))
 
     if show_all:
         for installed_ext in installed_extensions:
             if installed_ext.uuid not in enabled_uuids:
-                print(Icons.DOT_WHITE, Label.installed(installed_ext, enabled=False))
+                if only_uuid:
+                    print(installed_ext.metadata.uuid)
+                else:
+                    print(
+                        Icons.DOT_WHITE, Label.installed(installed_ext, enabled=False)
+                    )
 
     if verbose:
         print()


### PR DESCRIPTION
I have added a options `--only-uuid` in `list` command, to only output uuid (for easy storage/installation of extensions)
```shell
gext list --only-uuid
```
output:
```
places-menu@gnome-shell-extensions.gcampax.github.com
trayIconsReloaded@selfmade.pl
user-theme@gnome-shell-extensions.gcampax.github.com
```
and now you can do something like this
```shell
gext list --only-uuid > backup.txt
gext install $(cat backup.txt)
```