### PR TITLE
Fix GNOME Shell version parsing for pre-release versions (e.g. 48.beta)

### DIFF
--- a/gnome_extensions_cli/filesystem.py
+++ b/gnome_extensions_cli/filesystem.py
@@ -42,7 +42,7 @@ class FilesystemExtensionManager(ExtensionManager):
             ["gnome-shell", "--version"],
             text=True,
         )
-        matcher = fullmatch(r"GNOME Shell (?P<version>[0-9.]+)", stdout.strip())
+        matcher = fullmatch(r"GNOME Shell (?P<version>[0-9]+(?:\.[0-9]+)?)(?:\..+)?", stdout.strip())
         assert matcher is not None, "Cannot retrieve Gnome Shell version"
         return matcher.group("version")
 


### PR DESCRIPTION
This PR addresses an issue in the `FilesystemExtensionManager.get_current_shell_version()` method where the output from `gnome-shell --version` for GNOME Shell 48 (e.g., `"GNOME Shell 48.beta"`) fails to match the existing regex. The original regex (`r"GNOME Shell (?P<version>[0-9.]+)"`) only accepts digits and periods, causing an assertion failure when encountering a suffix like `.beta`.

```python
root@builder:~# ./.local/bin/gext -F install arcmenu@arcmenu.com
💥 Error: Cannot retrieve Gnome Shell version
Traceback (most recent call last):
  File "/root/./.local/bin/gext", line 8, in <module>
    sys.exit(run())
             ~~~^^
  File "/root/.local/share/pipx/venvs/gnome-extensions-cli/lib/python3.13/site-packages/gnome_extensions_cli/cli.py", line 130, in run
    raise error
  File "/root/.local/share/pipx/venvs/gnome-extensions-cli/lib/python3.13/site-packages/gnome_extensions_cli/cli.py", line 122, in run
    handler(args, manager, store)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/pipx/venvs/gnome-extensions-cli/lib/python3.13/site-packages/gnome_extensions_cli/commands/install.py", line 35, in run
    shell_version = manager.get_current_shell_version()
  File "/root/.local/share/pipx/venvs/gnome-extensions-cli/lib/python3.13/site-packages/gnome_extensions_cli/filesystem.py", line 46, in get_current_shell_version
    assert matcher is not None, "Cannot retrieve Gnome Shell version"
           ^^^^^^^^^^^^^^^^^^^
AssertionError: Cannot retrieve Gnome Shell version
```

**Changes:**
- Updated the regex to capture the numeric portion of the version (either a major version or a major.minor version) and ignore any additional non-numeric suffixes.
  - For example, the new regex captures `"48"` from `"GNOME Shell 48.beta"`.


![image](https://github.com/user-attachments/assets/2c1cef1c-59ba-4f38-a4b1-181b8f5cce59)
