### PR TITLE
Fix "conflicting subparser alias"

### DIFF
--- a/gnome_extensions_cli/cli.py
+++ b/gnome_extensions_cli/cli.py
@@ -79,7 +79,7 @@ def run():
         subparsers.add_parser("uninstall", aliases=[], help="uninstall extensions")
     )
     update.configure(
-        subparsers.add_parser("update", aliases=["un"], help="update extensions")
+        subparsers.add_parser("update", aliases=["u"], help="update extensions")
     )
 
     enable.configure(


### PR DESCRIPTION
Fixes the following error on Python 3.12:

```
Traceback (most recent call last):
  File "/home/jspence/.venv/bin/gnome-extensions-cli", line 7, in <module>
    sys.exit(run())
             ^^^^^
  File "/home/jspence/.venv/lib/python3.12/site-packages/gnome_extensions_cli/cli.py", line 72, in run
    subparsers.add_parser("update", aliases=["u"], help="update extensions")
  File "/usr/lib/python3.12/argparse.py", line 1234, in add_parser
    raise ArgumentError(
argparse.ArgumentError: argument {list,ls,install,i,uninstall,u,enable,disable,show,search}: conflicting subparser alias: u
```